### PR TITLE
deal with variant of NCBI taxonomy page to retrieve current rank

### DIFF
--- a/dabeplech/models/ncbi_taxonomy/__init__.py
+++ b/dabeplech/models/ncbi_taxonomy/__init__.py
@@ -1,0 +1,1 @@
+from .taxonomy import NCBITaxonomyAPIModel  # noqa

--- a/dabeplech/scrappers/ncbi_taxonomy/taxonomy.py
+++ b/dabeplech/scrappers/ncbi_taxonomy/taxonomy.py
@@ -30,8 +30,8 @@ class NCBITaxonomyScrapper:
     def retrieve_current_item(self):
         table_of_interest = self.soup.body.find_all('table')[3]
         name = table_of_interest.find_all('strong')[0].text
-        tax_id = table_of_interest.tr.td.text.split("Taxonomy ID:")[-1].split()[0]
-        rank = table_of_interest.find_all('strong')[2].text
+        tax_id = table_of_interest.tr.td.text.split("Taxonomy ID:", maxsplit=1)[-1].split()[0]
+        rank = table_of_interest.find_all('strong')[-2].text
         current_item = {
             'rank': rank,
             'tax_id': tax_id,

--- a/tests/dabeplech/scrappers/ncbi_taxonomy/data/tax_12345.html
+++ b/tests/dabeplech/scrappers/ncbi_taxonomy/data/tax_12345.html
@@ -5,7 +5,7 @@
     <meta name="keywords" content="national center for biotechnology information, ncbi, national library of medicine, nlm, national institutes of health, nih, database, archive, bookshelf, pubmed, pubmed central, bioinformatics, biomedicine,taxonomy, organism, phylogeny, sequence, database">
     <meta name="description" content="THE NCBI Taxonomy database allows browsing of the taxonomy tree, which contains a classification of organisms.">
     <meta name="ncbi_app" content="taxonomy"/>
-    <meta name="ncbi_phid" content="03EE7738F354AD010000000000000001"/>
+    <meta name="ncbi_phid" content="03ED22ACF35495B10000000000000001"/>
     <meta name="log_op" content="pageview"/>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <!-- Global Alert message support -->
@@ -143,7 +143,7 @@
         </td></tr>
         <tr><td><INPUT TYPE=submit NAME=butt VALUE="Display">
 	    <INPUT TYPE=hidden NAME=mode value="Undef">
-	    <INPUT TYPE=hidden NAME="old_id" value="33958">
+	    <INPUT TYPE=hidden NAME="old_id" value="12345">
 	    <INPUT ID=typetxt TYPE=text name="lvl" value="3" size=3>
 	    <LABEL FOR=typetxt ACCESSKEY=E> levels </LABEL>
 	      <LABEL FOR=filter ACCESSKEY=F>using filter:&nbsp;
@@ -158,118 +158,67 @@
       
     </table>
 <!--  the contents   -->
-  <title>Taxonomy browser (Lactobacillaceae)</title>
-<table width="100%"><tr><td valign="top"><h2><a href="wwwtax.cgi?mode=Tree&amp;id=33958&amp;lvl=3&amp;keep=1&amp;srchmode=1&amp;unlock">Lactobacillaceae</a></h2>
-Taxonomy ID: 33958<small> (for references in articles please use NCBI:txid33958)</small><br><fieldset><legend>current name</legend>
-<div><div><strong>Lactobacillaceae</strong>&nbsp;Winslow et al. 1917</div></div>
+  <title>Taxonomy browser (Bacillus virus GA1)</title>
+<table width="100%"><tr><td valign="top"><h2>Bacillus virus GA1<sup><small>&nbsp;<a class="note" href="#note1" title="Name is currently accepted by the International Committee on Taxonomy of Viruses">1)</a></small></sup></h2>
+Taxonomy ID: 12345<small> (for references in articles please use NCBI:txid12345)</small><br><fieldset><legend>current name</legend>
+<div><div><strong>Bacillus virus GA1</strong>, ICTV accepted<sup><small>&nbsp;<a class="note" href="#note1" title="Name is currently accepted by the International Committee on Taxonomy of Viruses">1)</a></small></sup></div></div>
+<div class="subord"><div class="subcat"><div class="nomrel">genbank acronym: </div>
+<div class="subname"><div><strong>GA-1</strong></div></div>
+</div>
+<div class="subcat"><div class="nomrelfolded">equivalent: </div>
+<div class="subname"><div><strong>Bacillus phage GA-1</strong></div>
+<div><strong>Bacteriophage GA-1</strong></div>
+<div><strong>bacteriophage GA1</strong></div>
+</div>
+</div>
+</div>
 </fieldset>
-NCBI BLAST name: <strong>firmicutes</strong><br>Rank: <strong>family</strong><br>Genetic code: <a href="/Taxonomy/taxonomyhome.html/index.cgi?chapter=cgencodes#SG11">Translation table 11 (Bacterial, Archaeal and Plant Plastid)</a><br><dl><dt><a href="wwwtax.cgi?mode=Info&amp;id=33958&amp;lvl=3&amp;keep=1&amp;srchmode=1&amp;unlock&amp;lin=s&amp;log_op=lineage_toggle">Lineage</a><em>( full )</em></dt>
-<dd><a ALT="no rank" href="wwwtax.cgi?mode=Undef&amp;id=131567&amp;lvl=3&amp;keep=1&amp;srchmode=1&amp;unlock" TITLE="no rank">cellular organisms</a>; <a ALT="superkingdom" href="wwwtax.cgi?mode=Undef&amp;id=2&amp;lvl=3&amp;keep=1&amp;srchmode=1&amp;unlock" TITLE="superkingdom">Bacteria</a>; <a ALT="clade" href="wwwtax.cgi?mode=Undef&amp;id=1783272&amp;lvl=3&amp;keep=1&amp;srchmode=1&amp;unlock" TITLE="clade">Terrabacteria group</a>; <a ALT="phylum" href="wwwtax.cgi?mode=Undef&amp;id=1239&amp;lvl=3&amp;keep=1&amp;srchmode=1&amp;unlock" TITLE="phylum">Firmicutes</a>; <a ALT="class" href="wwwtax.cgi?mode=Undef&amp;id=91061&amp;lvl=3&amp;keep=1&amp;srchmode=1&amp;unlock" TITLE="class">Bacilli</a>; <a ALT="order" href="wwwtax.cgi?mode=Undef&amp;id=186826&amp;lvl=3&amp;keep=1&amp;srchmode=1&amp;unlock" TITLE="order">Lactobacillales</a></dd>
+NCBI BLAST name: <strong>viruses</strong><br>Rank: <strong>species</strong><br>Genetic code: <a href="/Taxonomy/taxonomyhome.html/index.cgi?chapter=cgencodes#SG11">Translation table 11 (Bacterial, Archaeal and Plant Plastid)</a><br>Host: bacteria<br><dl><dt><a href="wwwtax.cgi?mode=Info&amp;id=12345&amp;lvl=3&amp;keep=1&amp;srchmode=1&amp;unlock&amp;lin=s&amp;log_op=lineage_toggle">Lineage</a><em>( full )</em></dt>
+<dd><a ALT="superkingdom" href="wwwtax.cgi?mode=Undef&amp;id=10239&amp;lvl=3&amp;keep=1&amp;srchmode=1&amp;unlock" TITLE="superkingdom">Viruses</a>; <a ALT="clade" href="wwwtax.cgi?mode=Undef&amp;id=2731341&amp;lvl=3&amp;keep=1&amp;srchmode=1&amp;unlock" TITLE="clade">Duplodnaviria</a>; <a ALT="clade" href="wwwtax.cgi?mode=Undef&amp;id=2731360&amp;lvl=3&amp;keep=1&amp;srchmode=1&amp;unlock" TITLE="clade">Heunggongvirae</a>; <a ALT="phylum" href="wwwtax.cgi?mode=Undef&amp;id=2731618&amp;lvl=3&amp;keep=1&amp;srchmode=1&amp;unlock" TITLE="phylum">Uroviricota</a>; <a ALT="class" href="wwwtax.cgi?mode=Undef&amp;id=2731619&amp;lvl=3&amp;keep=1&amp;srchmode=1&amp;unlock" TITLE="class">Caudoviricetes</a>; <a ALT="order" href="wwwtax.cgi?mode=Undef&amp;id=28883&amp;lvl=3&amp;keep=1&amp;srchmode=1&amp;unlock" TITLE="order">Caudovirales</a>; <a ALT="family" href="wwwtax.cgi?mode=Undef&amp;id=10744&amp;lvl=3&amp;keep=1&amp;srchmode=1&amp;unlock" TITLE="family">Podoviridae</a>; <a ALT="subfamily" href="wwwtax.cgi?mode=Undef&amp;id=542836&amp;lvl=3&amp;keep=1&amp;srchmode=1&amp;unlock" TITLE="subfamily">Picovirinae</a>; <a ALT="genus" href="wwwtax.cgi?mode=Undef&amp;id=186846&amp;lvl=3&amp;keep=1&amp;srchmode=1&amp;unlock" TITLE="genus">Salasvirus</a></dd>
 </dl>
 </td>
-<td align="right" valign="top" width="20%"><table align="right" border="1" valign="top"><tr><td align="center" bgcolor="#ccccff" colspan="3" valign="center"><strong>&nbsp;&nbsp;&nbsp;Entrez records&nbsp;&nbsp;&nbsp;</strong></td></tr>
+<td align="right" valign="top" width="20%"><table align="right" border="1" valign="top"><tr><td align="center" bgcolor="#ccccff" colspan="2" valign="center"><strong>&nbsp;&nbsp;&nbsp;Entrez records&nbsp;&nbsp;&nbsp;</strong></td></tr>
 <tr><td align="center" title="Entez database name" valign="bottom"><small>Database&nbsp;name</small></td>
-<td align="center" title="Entries linked to any taxa in this subtree of the taxonomy database" valign="bottom"><small>Subtree&nbsp;links</small></td>
 <td align="center" title="Entries linked directly to this taxon node in the taxonomy database" valign="bottom"><small>Direct&nbsp;links</small></td>
 </tr>
 <tr><td><span style="color:#0000A0">Nucleotide</span></td>
-<td align="right"><a href="/nuccore/?term=txid33958[Organism:exp]"><span style="color:#0000A0">686,742</span></a></td>
-<td align="right"><span style="color:#0000A0">-</span></td>
+<td align="right"><a href="/nuccore/?term=txid12345[Organism:noexp]"><span style="color:#0000A0">8</span></a></td>
 </tr>
 <tr><td><span style="color:#F00000">Protein</span></td>
-<td align="right"><a href="/protein/?term=txid33958[Organism:exp]"><span style="color:#F00000">7,271,236</span></a></td>
-<td align="right"><a href="/protein/?term=txid33958[Organism:noexp]"><span style="color:#F00000">1,169</span></a></td>
+<td align="right"><a href="/protein/?term=txid12345[Organism:noexp]"><span style="color:#F00000">75</span></a></td>
 </tr>
 <tr><td><span style="color:#007000">Structure</span></td>
-<td align="right"><a href="/structure/?term=txid33958[Organism:exp]"><span style="color:#007000">459</span></a></td>
-<td align="right"><span style="color:#007000">-</span></td>
+<td align="right"><a href="/structure/?term=txid12345[Organism:noexp]"><span style="color:#007000">1</span></a></td>
 </tr>
 <tr><td><span style="color:#F000F0">Genome</span></td>
-<td align="right"><a href="/genome/?term=txid33958[Organism:exp]"><span style="color:#F000F0">230</span></a></td>
-<td align="right"><span style="color:#F000F0">-</span></td>
-</tr>
-<tr><td><span style="color:#606090">Popset</span></td>
-<td align="right"><a href="/popset/?term=txid33958[Organism:exp]"><span style="color:#606090">1,778</span></a></td>
-<td align="right"><a href="/popset/?term=txid33958[Organism:noexp]"><span style="color:#606090">1,021</span></a></td>
-</tr>
-<tr><td><span style="color:#800000">Conserved&nbsp;Domains</span></td>
-<td align="right"><a href="/cdd/?term=txid33958[Organism:exp]"><span style="color:#800000">18</span></a></td>
-<td align="right"><a href="/cdd/?term=txid33958[Organism:noexp]"><span style="color:#800000">1</span></a></td>
-</tr>
-<tr><td><span style="color:#00CC00">GEO&nbsp;Datasets</span></td>
-<td align="right"><a href="/gds/?term=txid33958[Organism:exp]"><span style="color:#00CC00">1,531</span></a></td>
-<td align="right"><span style="color:#00CC00">-</span></td>
-</tr>
-<tr><td><span style="color:#804000">PubMed&nbsp;Central</span></td>
-<td align="right"><a href="/pmc/?term=txid33958[Organism:exp]&amp;pmfilter_Fulltext=off"><span style="color:#804000">36,445</span></a></td>
-<td align="right"><a href="/pmc/?term=txid33958[Organism:noexp]&amp;pmfilter_Fulltext=off"><span style="color:#804000">2,360</span></a></td>
+<td align="right"><a href="/genome/?term=txid12345[Organism:noexp]"><span style="color:#F000F0">1</span></a></td>
 </tr>
 <tr><td><span style="color:#8080C0">Gene</span></td>
-<td align="right"><a href="/gene/?term=txid33958[Organism:exp]"><span style="color:#8080C0">298,085</span></a></td>
-<td align="right"><span style="color:#8080C0">-</span></td>
-</tr>
-<tr><td><span style="color:#408080">SRA&nbsp;Experiments</span></td>
-<td align="right"><a href="/sra/?term=txid33958[Organism:exp]"><span style="color:#408080">4,727</span></a></td>
-<td align="right"><span style="color:#408080">-</span></td>
+<td align="right"><a href="/gene/?term=txid12345[Organism:noexp]"><span style="color:#8080C0">53</span></a></td>
 </tr>
 <tr><td><span style="color:#C080FF">Protein&nbsp;Clusters</span></td>
-<td align="right"><a href="/proteinclusters/?term=txid33958[Organism:exp]"><span style="color:#C080FF">20,246</span></a></td>
-<td align="right"><a href="/proteinclusters/?term=txid33958[Organism:noexp]"><span style="color:#C080FF">237</span></a></td>
+<td align="right"><a href="/proteinclusters/?term=txid12345[Organism:noexp]"><span style="color:#C080FF">1</span></a></td>
 </tr>
 <tr><td><span style="color:#C00000">Identical&nbsp;Protein&nbsp;Groups</span></td>
-<td align="right"><a href="/ipg/?term=txid33958[Organism:exp]"><span style="color:#C00000">2,170,885</span></a></td>
-<td align="right"><a href="/ipg/?term=txid33958[Organism:noexp]"><span style="color:#C00000">1,169</span></a></td>
-</tr>
-<tr><td><span style="color:#FF80C0">Bio&nbsp;Project</span></td>
-<td align="right"><a href="/bioproject/?term=txid33958[Organism:exp]"><span style="color:#FF80C0">2,122</span></a></td>
-<td align="right"><a href="/bioproject/?term=txid33958[Organism:noexp]"><span style="color:#FF80C0">1</span></a></td>
-</tr>
-<tr><td><span style="color:#FF8000">Bio&nbsp;Sample</span></td>
-<td align="right"><a href="/biosample/?term=txid33958[Organism:exp]"><span style="color:#FF8000">8,588</span></a></td>
-<td align="right"><span style="color:#FF8000">-</span></td>
-</tr>
-<tr><td><span style="color:#0080C0">Bio&nbsp;Systems</span></td>
-<td align="right"><a href="/biosystems/?term=txid33958[Organism:exp]"><span style="color:#0080C0">13,253</span></a></td>
-<td align="right"><span style="color:#0080C0">-</span></td>
+<td align="right"><a href="/ipg/?term=txid12345[Organism:noexp]"><span style="color:#C00000">36</span></a></td>
 </tr>
 <tr><td><span style="color:#804000">Assembly</span></td>
-<td align="right"><a href="/assembly/?term=txid33958[Organism:exp]"><span style="color:#804000">3,560</span></a></td>
-<td align="right"><span style="color:#804000">-</span></td>
+<td align="right"><a href="/assembly/?term=txid12345[Organism:noexp]"><span style="color:#804000">1</span></a></td>
 </tr>
 <tr><td><span style="color:#C0C000">Probe</span></td>
-<td align="right"><a href="/probe/?term=txid33958[Organism:exp]"><span style="color:#C0C000">525</span></a></td>
-<td align="right"><span style="color:#C0C000">-</span></td>
-</tr>
-<tr><td><span style="color:#008040">PubChem&nbsp;BioAssay</span></td>
-<td align="right"><a href="/pcassay/?term=txid33958[Organism:exp]"><span style="color:#008040">527</span></a></td>
-<td align="right"><span style="color:#008040">-</span></td>
+<td align="right"><a href="/probe/?term=txid12345[Organism:noexp]"><span style="color:#C0C000">10</span></a></td>
 </tr>
 <tr><td><span style="color:#000080">Taxonomy</span></td>
-<td align="right"><a href="/taxonomy/?term=txid33958[Subtree]"><span style="color:#000080">2,993</span></a></td>
-<td align="right"><a href="/taxonomy/?term=33958[uid]"><span style="color:#000080">1</span></a></td>
+<td align="right"><a href="/taxonomy/?term=12345[uid]"><span style="color:#000080">1</span></a></td>
 </tr>
 </table></td>
 </tr></table>
 <p></p>
-<h3>Comments and References:</h3>
+<h3>Notes:</h3>
 <p></p>
-<table class="citation"><tr><td><span class="citimage"><a href="/pubmed/10555321" target="ref"><img src="/Taxonomy/Gifs/pubmed_logo.png" title="Reference to PubMed document"></a></span></td>
-<td><span class="citkey"><a href="/pubmed/10555321" target="ref">Groisillier A &amp; Lonvaud-Funel A (1999)</a><div class="cittext">Groisillier, A., and Lonvaud-Funel, A. &quot;Comparison of partial malolactic enzyme gene sequences for phylogenetic analysis of some lactic acid bacteria species and relationships with the malic enzyme.&quot; Int. J. Syst. Bacteriol. (1999) 49:1417-1428.</div>
-</span></td>
-</tr></table>
-<table class="citation"><tr><td><span class="citimage"><a href="https://ijs.microbiologyresearch.org/content/journal/ijsem/10.1099/00207713-30-1-225" target="ref"><img src="/Taxonomy/Gifs/linkout_logo_small.png" title="LinkOut"></a></span></td>
-<td><span class="citkey"><a href="https://ijs.microbiologyresearch.org/content/journal/ijsem/10.1099/00207713-30-1-225" target="ref">Skerman VBD et al. (1980)</a><div class="cittext">Skerman, V.B.D., McGowan, V., and Sneath, P.H.A. (editors). &quot;Approved lists of bacterial names.&quot; Int. J. Syst. Bacteriol. (1980) 30:225-420. [No PubMed record available.]</div>
-</span></td>
-</tr></table>
-<table class="citation"><tr><td><span class="citimage"><a href="/pubmed/9168311" target="ref"><img src="/Taxonomy/Gifs/pubmed_logo.png" title="Reference to PubMed document"></a></span></td>
-<td><span class="citkey"><a href="/pubmed/9168311" target="ref">Stiles ME &amp; Holzapfel WH (1997)</a><div class="cittext">Stiles, M.E., and Holzapfel, W.H. &quot;Lactic acid bacteria of foods and their current taxonomy.&quot; Int. J. Food Microbiol. (1997) 36:1-29.</div>
-</span></td>
-</tr></table>
-<table class="citation"><tr><td><span class="citimage"></span></td>
-<td><span class="citkey">Winslow CEA et al. (1917)<div class="cittext">Winslow, C.E.A., Broadhurst, J., Buchanan, R.E., Krumwiede Jr., C., Rogers, L.A., and Smith, G.H. &quot;The families and the genera of the bacteria. Preliminary report of the Committee of the Society of American Bacteriologists on characterization and classification of bacterial types.&quot; J. Bacteriol. (1917) 2:505-566. [No PubMed record available.]</div>
-</span></td>
-</tr></table>
-<script type="text/javascript">var meta = document.createElement('meta');meta.name="ncbi_pdid";meta.content="info";document.getElementsByTagName('head')[0].appendChild(meta);</script>
+<ul><li id="note1" name="note1" type="none" value="1"><strong>1) </strong>Name is currently accepted by the International Committee on Taxonomy of Viruses</li></ul>
+<p></p>
+<a href="https://www.ncbi.nlm.nih.gov/labs/virus/vssi/#/virus?SeqType_s=Nucleotide&amp;VirusLineage_ss=Bacillus+virus+GA1,%20taxid:12345">View and Analyze sequences in NCBI Virus</a><br><a href="http://www.ictvonline.org/">ICTV homepage</a><br><script type="text/javascript">var meta = document.createElement('meta');meta.name="ncbi_pdid";meta.content="info";document.getElementsByTagName('head')[0].appendChild(meta);</script>
 
   <HR><P><strong>Disclaimer:</strong> The NCBI taxonomy database is not an authoritative
   source for nomenclature or classification - please consult the

--- a/tests/dabeplech/scrappers/ncbi_taxonomy/test_taxonomy.py
+++ b/tests/dabeplech/scrappers/ncbi_taxonomy/test_taxonomy.py
@@ -51,6 +51,21 @@ class TestNCBITaxonomyScrapper(TestCase):
         tested_dict = scrapper.retrieve_current_item()
         self.assertDictEqual(tested_dict, expected_dict)
 
+    def test_retrieve_current_item_variant_1(self):
+        """
+        Some entry has different display and more information, for instance tax_id 12345
+        """
+        file_path = os.path.join(os.path.dirname(__file__), 'data/tax_12345.html')
+        tax_file = open(file_path, "rb")
+        scrapper = NCBITaxonomyScrapper(tax_file)
+        expected_dict = {
+            'rank': 'species',
+            'tax_id': '12345',
+            'name': 'Bacillus virus GA1'
+        }
+        tested_dict = scrapper.retrieve_current_item()
+        self.assertDictEqual(tested_dict, expected_dict)
+
     def test_retrieve_hierarchy(self):
         scrapper = NCBITaxonomyScrapper(self.file)
         expected_list = [


### PR DESCRIPTION
## Description

Format of NCBI taxonomy pages may vary depending the information available. The current PR deal with new case (`tax_id=12345`). We might expect more variants to refine the scrapper.

#### Changelogs

* Fix bug and deal with variant of NCBI taxonomy item page

## Definition of Done

* [x]  New lines are tested with unit tests (mandatory for the addition of a new parser: [More info](https://dabeplech.readthedocs.io/en/latest/contribution_guide/parser.html))
* [x]  Documentation has been updated (When adding new API connector: [More info](https://dabeplech.readthedocs.io/en/latest/contribution_guide/docs.html))
* [x]  Pull Request has been revised by a maintainer
