### PR TITLE
add API to query DOI.org

### DIFF
--- a/dabeplech/__init__.py
+++ b/dabeplech/__init__.py
@@ -16,3 +16,6 @@ from .pdbe import (  # noqa
     PDBeUniprotMappingAPI,
     PDBePFAMMappingAPI,
 )
+from .doi import (  # noqa
+    DOIAPI,
+)

--- a/dabeplech/doi.py
+++ b/dabeplech/doi.py
@@ -1,0 +1,9 @@
+from dabeplech.base import BaseAPI, GETMixin
+
+
+class DOIAPI(BaseAPI, GETMixin):
+    BASE_URL = "https://dx.doi.org"
+    HEADERS = {
+        'Content-type': 'application/json',
+        'Accept': 'application/vnd.citationstyles.csl+json'
+    }

--- a/docs/api_docs/api_services.rst
+++ b/docs/api_docs/api_services.rst
@@ -12,7 +12,7 @@ KEGG
     :show-inheritance:
 
 
-TogoWS
+TogoS
 ======
 
 .. automodule:: dabeplech.togows
@@ -39,3 +39,12 @@ PDBe
     :members:
     :undoc-members:
     :show-inheritance:
+
+DOI
+===
+
+.. autoclass:: dabeplech.doi.DOIAPI
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :inherited-members: get

--- a/docs/api_docs/api_services.rst
+++ b/docs/api_docs/api_services.rst
@@ -12,7 +12,7 @@ KEGG
     :show-inheritance:
 
 
-TogoS
+TogoWS
 ======
 
 .. automodule:: dabeplech.togows

--- a/docs/user_guide/supported_api.rst
+++ b/docs/user_guide/supported_api.rst
@@ -5,7 +5,9 @@ List of supported APIs
 - KEGG_: Database resource for understanding high-level functions and utilities of the biological system.
 - togoWS_: Uniformed REST API for accessing major bioinformatics data resources and data formats.
 - PDBe_: PDBe is a founding member of the Worldwide Protein Data Bank which collects, organises and disseminates data on biological macromolecular structures.
+- DOI_: The International DOI Foundation (IDF), a not-for-profit membership organization that is the governance and management body for the federation of Registration Agencies providing Digital Object Identifier (DOI) services and registration, and is the registration authority for the ISO standard (ISO 26324) for the DOI system.
 
 .. _KEGG: https://www.kegg.jp/kegg/rest/keggapi.html
 .. _togoWS: http://togows.dbcls.jp/
 .. _PDBe: https://www.ebi.ac.uk/pdbe/api/
+.. _DOI: https://www.doi.org

--- a/tests/scripts/api_status.py
+++ b/tests/scripts/api_status.py
@@ -10,6 +10,7 @@ import sys
 from kegg_api_status import test_keggapi
 from togows_api_status import test_togowsentryapi
 from pdbe_api_status import test_pdbeapi
+from doi_api_status import test_doiapi
 
 logging.basicConfig()
 logger = logging.getLogger()
@@ -35,6 +36,7 @@ def run():
     test_togowsentryapi()
     test_keggapi()
     test_pdbeapi()
+    test_doiapi()
 
 
 if __name__ == "__main__":

--- a/tests/scripts/doi_api_status.py
+++ b/tests/scripts/doi_api_status.py
@@ -1,0 +1,50 @@
+from dabeplech import DOIAPI
+
+from utils import _format_print
+
+
+def _expected_working_doi():
+    tests = [
+        ('10.12688/f1000research.12974.1', DOIAPI)
+    ]
+    for i in tests:
+        entry_id = i[0]
+        api_connector = i[1]
+        api = api_connector()
+        print(f"Test getting {entry_id} from DOI database from base URL: {api.BASE_URL}:")
+        try:
+            content = api.get(entry_id)  # noqa
+            print(_format_print("Status", "OK", "green"))
+            if content:
+                print(_format_print(f"Content (format:{type(content)})", "NOT EMPTY", "green"))
+            else:
+                print(_format_print("Content", "EMPTY", "red"))
+        except Exception:
+            print(_format_print("Status", "ERROR", "red"))
+        finally:
+            print(f" --> Requested URL: {api.last_url_requested}")
+
+
+def _expected_not_working_doi():
+    tests = [
+        ('10.12688f1000research.12974.1', DOIAPI)
+    ]
+    for i in tests:
+        entry_id = i[0]
+        api_connector = i[1]
+        api = api_connector()
+        print(f"Test getting {entry_id} from DOI database from base URL: {api.BASE_URL}:")
+        try:
+            api = api_connector()
+            content = api.get(entry_id)  # noqa
+            print(_format_print("Status", "OK", "red"))
+        except Exception:
+            print(_format_print("Status", "ERROR", "green"))
+        finally:
+            print(f" --> Requested URL: {api.last_url_requested}")
+
+
+def test_doiapi():
+    print("---------- Testing DOI API endpoints... ----------")
+    _expected_working_doi()
+    _expected_not_working_doi()


### PR DESCRIPTION
## Description
Add an endpoint to query the DOI (https://dx.doi.org) endpoint to retrieve information in the JSON format

#### Changelogs

* Add an endpoint to query the DOI (https://dx.doi.org) endpoint to retrieve information in the JSON format

## Definition of Done

* [x]  New lines are tested with unit tests (mandatory for the addition of a new parser: [More info](https://dabeplech.readthedocs.io/en/latest/contribution_guide/parser.html))
* [X]  Documentation has been updated (When adding new API connector: [More info](https://dabeplech.readthedocs.io/en/latest/contribution_guide/docs.html))
* [x]  Pull Request has been revised by a maintainer
