### PR TITLE
add API to query https://hal.archives-ouvertes.org

### DIFF
--- a/dabeplech/__init__.py
+++ b/dabeplech/__init__.py
@@ -19,3 +19,6 @@ from .pdbe import (  # noqa
 from .doi import (  # noqa
     DOIAPI,
 )
+from .hal import (  #noqa
+    HALAPI,
+)

--- a/dabeplech/hal.py
+++ b/dabeplech/hal.py
@@ -1,0 +1,30 @@
+from urllib.parse import urljoin
+
+from dabeplech.base import BaseAPI, GETMixin
+
+
+class HALAPI(BaseAPI, GETMixin):
+    BASE_URL = "https://api.archives-ouvertes.fr/search/"
+
+    def find(self, doi: str):
+        """
+        :param doi: the DOI of the searched document
+        :return: response from HAL API
+        """
+        full_url = urljoin(self.url, f'?fq=doiId_s:"{doi}"&fl=*&wt=json')
+        response = self.session.get(full_url)
+        self.last_url_requested = full_url
+        response.raise_for_status()
+        return response.json()
+
+    def get(self, hal_id: int):
+        """
+        :param hal_id: the HAL ID of adocument
+        :return: response from HAL API
+        """
+        full_url = urljoin(self.url, f'hal?q=docid:{hal_id}&fl=*&wt=json')
+        response = self.session.get(full_url)
+        self.last_url_requested = full_url
+        response.raise_for_status()
+        return response.json()
+

--- a/docs/api_docs/api_services.rst
+++ b/docs/api_docs/api_services.rst
@@ -48,3 +48,12 @@ DOI
     :undoc-members:
     :show-inheritance:
     :inherited-members: get
+
+HAL
+===
+
+.. autoclass:: dabeplech.hal.HALAPI
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :inherited-members: get

--- a/docs/user_guide/supported_api.rst
+++ b/docs/user_guide/supported_api.rst
@@ -6,8 +6,10 @@ List of supported APIs
 - togoWS_: Uniformed REST API for accessing major bioinformatics data resources and data formats.
 - PDBe_: PDBe is a founding member of the Worldwide Protein Data Bank which collects, organises and disseminates data on biological macromolecular structures.
 - DOI_: The International DOI Foundation (IDF), a not-for-profit membership organization that is the governance and management body for the federation of Registration Agencies providing Digital Object Identifier (DOI) services and registration, and is the registration authority for the ISO standard (ISO 26324) for the DOI system.
+- HAL_: HAL is an open archive where authors can deposit scholarly documents from all academic fields.
 
 .. _KEGG: https://www.kegg.jp/kegg/rest/keggapi.html
 .. _togoWS: http://togows.dbcls.jp/
 .. _PDBe: https://www.ebi.ac.uk/pdbe/api/
 .. _DOI: https://www.doi.org
+.. _HAL: https://hal.archives-ouvertes.fr/

--- a/tests/scripts/api_status.py
+++ b/tests/scripts/api_status.py
@@ -11,6 +11,7 @@ from kegg_api_status import test_keggapi
 from togows_api_status import test_togowsentryapi
 from pdbe_api_status import test_pdbeapi
 from doi_api_status import test_doiapi
+from hal_api_status import test_halapi
 
 logging.basicConfig()
 logger = logging.getLogger()
@@ -37,6 +38,7 @@ def run():
     test_keggapi()
     test_pdbeapi()
     test_doiapi()
+    test_halapi()
 
 
 if __name__ == "__main__":

--- a/tests/scripts/hal_api_status.py
+++ b/tests/scripts/hal_api_status.py
@@ -1,0 +1,50 @@
+from dabeplech import HALAPI
+
+from utils import _format_print
+
+
+def _expected_working_hal():
+    tests = [
+        ('10.12688/f1000research.12974.1', HALAPI)
+    ]
+    for i in tests:
+        entry_id = i[0]
+        api_connector = i[1]
+        api = api_connector()
+        print(f"Test getting {entry_id} from HAL database from base URL: {api.BASE_URL}:")
+        try:
+            content = api.find(doi=entry_id)  # noqa
+            print(_format_print("Status", "OK", "green"))
+            if content:
+                print(_format_print(f"Content (format:{type(content)})", "NOT EMPTY", "green"))
+            else:
+                print(_format_print("Content", "EMPTY", "red"))
+        except Exception:
+            print(_format_print("Status", "ERROR", "red"))
+        finally:
+            print(f" --> Requested URL: {api.last_url_requested}")
+
+
+def _expected_not_working_hal():
+    tests = [
+        ('10.12688f1000research.12974.1', HALAPI)
+    ]
+    for i in tests:
+        entry_id = i[0]
+        api_connector = i[1]
+        api = api_connector()
+        print(f"Test getting {entry_id} from HAL database from base URL: {api.BASE_URL}:")
+        try:
+            api = api_connector()
+            content = api.get(doi=entry_id)  # noqa
+            print(_format_print("Status", "OK", "red"))
+        except Exception:
+            print(_format_print("Status", "ERROR", "green"))
+        finally:
+            print(f" --> Requested URL: {api.last_url_requested}")
+
+
+def test_halapi():
+    print("---------- Testing DOI API endpoints... ----------")
+    _expected_working_hal()
+    _expected_not_working_hal()


### PR DESCRIPTION
## Description

Add an endpoint to query the HAL (https://hal.archives-ouvertes.org) endpoint to retrieve information in the JSON format

#### Changelogs

* Add an endpoint to query the HAL (https://hal.archives-ouvertes.org) endpoint to retrieve information in the JSON format

#### Issue(s)

*Indicates which issue is related to this Pull Request*

Fixes #

## Definition of Done

* [x]  New lines are tested with unit tests (mandatory for the addition of a new parser: [More info](https://dabeplech.readthedocs.io/en/latest/contribution_guide/parser.html))
* [x]  Documentation has been updated (When adding new API connector: [More info](https://dabeplech.readthedocs.io/en/latest/contribution_guide/docs.html))
* [x]  Pull Request has been revised by a maintainer
