### PR TITLE
add a module to handle looking up OLS for ontology terms

### DIFF
--- a/dabeplech/__init__.py
+++ b/dabeplech/__init__.py
@@ -22,3 +22,6 @@ from .doi import (  # noqa
 from .hal import (  #noqa
     HALAPI,
 )
+from .ols import (  #noqa
+    OLSAPI,
+)

--- a/dabeplech/ols.py
+++ b/dabeplech/ols.py
@@ -1,0 +1,14 @@
+from dabeplech.base import BaseAPI, GETMixin
+from urllib.parse import urljoin
+
+class OLSAPI(BaseAPI, GETMixin):
+    BASE_URL = "https://www.ebi.ac.uk/ols/api/ontologies/go/terms/"
+
+    def get_term(self, entry_id: str):
+        """
+        Perform GET request to the service using the ontology term ID only
+
+        :param entry_id: short ID of the ontology concept (e.g. GO_0008150)
+        :param params: query params for the request
+        """
+        return self.get(f"http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252F{entry_id}")

--- a/docs/api_docs/api_services.rst
+++ b/docs/api_docs/api_services.rst
@@ -57,3 +57,12 @@ HAL
     :undoc-members:
     :show-inheritance:
     :inherited-members: get
+
+OLS
+===
+
+.. autoclass:: dabeplech.ols.OLSAPI
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :inherited-members: get

--- a/docs/user_guide/supported_api.rst
+++ b/docs/user_guide/supported_api.rst
@@ -7,9 +7,12 @@ List of supported APIs
 - PDBe_: PDBe is a founding member of the Worldwide Protein Data Bank which collects, organises and disseminates data on biological macromolecular structures.
 - DOI_: The International DOI Foundation (IDF), a not-for-profit membership organization that is the governance and management body for the federation of Registration Agencies providing Digital Object Identifier (DOI) services and registration, and is the registration authority for the ISO standard (ISO 26324) for the DOI system.
 - HAL_: HAL is an open archive where authors can deposit scholarly documents from all academic fields.
+- OLS_: The Ontology Lookup Service (OLS) is a repository for biomedical ontologies that aims to provide a single point of access to the latest ontology versions.
+
 
 .. _KEGG: https://www.kegg.jp/kegg/rest/keggapi.html
 .. _togoWS: http://togows.dbcls.jp/
 .. _PDBe: https://www.ebi.ac.uk/pdbe/api/
 .. _DOI: https://www.doi.org
 .. _HAL: https://hal.archives-ouvertes.fr/
+.. _OLS: https://www.ebi.ac.uk/ols/index

--- a/tests/scripts/api_status.py
+++ b/tests/scripts/api_status.py
@@ -12,6 +12,7 @@ from togows_api_status import test_togowsentryapi
 from pdbe_api_status import test_pdbeapi
 from doi_api_status import test_doiapi
 from hal_api_status import test_halapi
+from ols_api_status import test_olsapi
 
 logging.basicConfig()
 logger = logging.getLogger()
@@ -39,6 +40,7 @@ def run():
     test_pdbeapi()
     test_doiapi()
     test_halapi()
+    test_olsapi()
 
 
 if __name__ == "__main__":

--- a/tests/scripts/ols_api_status.py
+++ b/tests/scripts/ols_api_status.py
@@ -1,0 +1,50 @@
+from dabeplech import OLSAPI
+
+from utils import _format_print
+
+
+def _expected_working_ols():
+    tests = [
+        ('GO_0008150', OLSAPI)
+    ]
+    for i in tests:
+        entry_id = i[0]
+        api_connector = i[1]
+        api = api_connector()
+        print(f"Test getting {entry_id} from GO database from OLS base URL: {api.BASE_URL}:")
+        try:
+            content = api.get_term(entry_id)  # noqa
+            print(_format_print("Status", "OK", "green"))
+            if content:
+                print(_format_print(f"Content (format:{type(content)})", "NOT EMPTY", "green"))
+            else:
+                print(_format_print("Content", "EMPTY", "red"))
+        except Exception:
+            print(_format_print("Status", "ERROR", "red"))
+        finally:
+            print(f" --> Requested URL: {api.last_url_requested}")
+
+
+def _expected_not_working_ols():
+    tests = [
+        ('GA_0008150', OLSAPI)
+    ]
+    for i in tests:
+        entry_id = i[0]
+        api_connector = i[1]
+        api = api_connector()
+        print(f"Test getting {entry_id} from GO database from OLS base URL: {api.BASE_URL}:")
+        try:
+            api = api_connector()
+            content = api.get_term(entry_id)  # noqa
+            print(_format_print("Status", "OK", "red"))
+        except Exception:
+            print(_format_print("Status", "ERROR", "green"))
+        finally:
+            print(f" --> Requested URL: {api.last_url_requested}")
+
+
+def test_olsapi():
+    print("---------- Testing DOI API endpoints... ----------")
+    _expected_working_ols()
+    _expected_not_working_ols()


### PR DESCRIPTION
## Description

Add an endpoint to query Ontology Lookup Service (https://www.ebi.ac.uk/ols/index)

#### Changelogs

* a first get_term method to query by ontology term ID

## Definition of Done

* [x]  New lines are tested with unit tests (mandatory for the addition of a new parser: [More info](https://dabeplech.readthedocs.io/en/latest/contribution_guide/parser.html))
* [x]  Documentation has been updated (When adding new API connector: [More info](https://dabeplech.readthedocs.io/en/latest/contribution_guide/docs.html))
* [x]  Pull Request has been revised by a maintainer
